### PR TITLE
fix(deb): attach .debs to the release and drop Ubuntu 22.04

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -24,7 +24,9 @@ jobs:
           - { image: 'debian:trixie-slim',   codename: trixie,      experimental: false }
           - { image: 'debian:forky-slim',    codename: forky,       experimental: true  }
           - { image: 'debian:sid-slim',      codename: sid,         experimental: true  }
-          - { image: 'ubuntu:22.04',         codename: jammy,       experimental: false }
+          # Ubuntu 22.04 (jammy) is intentionally excluded: its PipeWire is too old for
+          # the `libspa` crate the `audio` feature needs (missing spa_meta_* symbols), so
+          # the build can't link. 22.04 users install via `cargo install` or the tarball.
           - { image: 'ubuntu:24.04',         codename: noble,       experimental: false }
           - { image: 'ubuntu:26.04',         codename: ubuntu2604,  experimental: true  }
     continue-on-error: ${{ matrix.experimental }}
@@ -79,6 +81,9 @@ jobs:
       - name: Attach to the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job has no checkout, so `gh` can't infer the repo from git; name it
+          # explicitly, otherwise every `gh release …` fails with "not a git repository".
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eux
           tag="${GITHUB_REF_NAME}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project are documented here. The format is based on
 
 - **`wlr-draw save`** — paths containing spaces are no longer truncated (#3).
 - **`wlr-draw`** — a very short arrow no longer panics while sizing its head.
-- **Debian / Ubuntu `.deb`** — now built per distro (Debian 12–sid, Ubuntu 22.04–26.04) so
+- **Debian / Ubuntu `.deb`** — now built per distro (Debian 12–sid, Ubuntu 24.04–26.04) so
   it links against that distro's FFmpeg / Leptonica; fixes `liblept.so.5` / `libavutil.so.58`
   load failures on Debian 13 (#1).
 - **`wlr-peek doctor`** — verdicts reflect the two capture floors (screen 0.19/1.11,

--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ one matching your system:
 | Debian 12 (bookworm) | `…_amd64.bookworm.deb` |
 | Debian 13 (trixie) | `…_amd64.trixie.deb` |
 | Debian 14 (forky) / sid | `…_amd64.forky.deb` / `…_amd64.sid.deb` |
-| Ubuntu 22.04 / 24.04 / 26.04 | `…_amd64.noble.deb`, etc. |
+| Ubuntu 24.04 (noble) / 26.04 | `…_amd64.noble.deb` / `…_amd64.ubuntu2604.deb` |
+
+Ubuntu 22.04 has no `.deb` (its PipeWire is too old for the audio engine); install it with
+`cargo install wlr-utils` or the prebuilt tarball / installer above.
 
 > [!IMPORTANT]
 > These `.deb`s link **dynamically** against the FFmpeg (`libavutil`) and Leptonica


### PR DESCRIPTION
The `v1.4.0` release shipped with **no `.deb` assets** because of two bugs in `deb.yml`. I've already attached the 6 working `.deb`s to the `v1.4.0` release by hand; this PR fixes the pipeline for future releases.

## Bugs

1. **`upload` job couldn't reach the repo.** It has no `actions/checkout`, so `gh` fell back to git for the repo name and every `gh release …` call failed with `fatal: not a git repository`. The wait loop spun for 10 min and the upload then errored — **zero `.deb`s attached**. Fixed by setting `GH_REPO: ${{ github.repository }}`.
2. **Ubuntu 22.04 (jammy) can't build.** Its PipeWire is too old for the `libspa` crate the `audio` feature needs (`error[E0425]: cannot find function spa_meta_first in crate spa_sys`, …). Removed from the matrix — cargo-dist's tarball already builds on 24.04 for exactly this reason (`dist-workspace.toml`). 22.04 users install via `cargo install` or the tarball.

## Docs
- `README.md` asset table: Ubuntu row now 24.04 / 26.04, with a note that 22.04 has no `.deb`.
- `CHANGELOG.md`: distro range corrected to Ubuntu 24.04–26.04.

## Note
No new release is needed — `v1.4.0` is already complete (tarball + installer + all 6 `.deb`s now attached). This just prevents the same failure next time.